### PR TITLE
Update Build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -68,6 +68,7 @@
         opt ? "" : "-s ASSERTIONS=2",
         "-s NO_FILESYSTEM=1",
         "-s NO_EXIT_RUNTIME=1",
+	"-s EXTRA_EXPORTED_RUNTIME_METHODS=['ccall']",
         "-s TOTAL_MEMORY=" + (80 * MB),
     ].filter(function (v) {return v;}).join(" ");
     


### PR DESCRIPTION
Added the emscripten flag: -s EXTRA_EXPORTED_RUNTIME_METHODS=['ccall']
Outlined here: 
https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-ccall-cwrap

Apparently this was a change a few months ago.